### PR TITLE
polkitex.py: change shebang to indicate python 2

### DIFF
--- a/polkitex.py
+++ b/polkitex.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/python2
 
 # Polkit Explorer
 # View/Explore all entries within a Linux Polkit XML file


### PR DESCRIPTION
Some distributions such as Arch Linux use python 3 as default python interpreter. See:

https://www.python.org/dev/peps/pep-0394/